### PR TITLE
Change zoomus to zoom as it's been migrated over there

### DIFF
--- a/mac
+++ b/mac
@@ -153,7 +153,7 @@ cask "flycut"
 cask "bitwarden"
 cask "caffeine"
 cask "docker"
-cask "zoomus"
+cask "zoom"
 cask "tableplus"
 EOF
 


### PR DESCRIPTION
See title!

i actually created a pull request on the original underlying repo we forked from somehow. that's embarrassing.

though i really want to verify this does what i expect, though i'd be shocked if it didn't.

Original error:
```
ryan@MacBook-Pro laptop % brew install zoomus
==> Caveats
RENAME WARNING

Due to prevalent user confusion, the zoomus cask (this one) will be renamed to zoom.
In the meantime, zoomus will install zoom for you as a dependency, but you should update your scripts.

We’re aware this solution is subpar. If you’d like to help us improve it,
we accept PRs and need the equivalent of formula_renames.json for casks: https://docs.brew.sh/Rename-A-Formula

To migrate now, do:
  brew uninstall zoomus
  brew install zoom
```