### PR TITLE
chore(script): update node version to match django repository

### DIFF
--- a/mac
+++ b/mac
@@ -161,8 +161,7 @@ fancy_echo "Installing ohmyzsh framework for zsh ..."
 sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
 # fancy_echo "Installing NodeJS versions..."
-nvm install 10
-nvm install 12
+nvm install 16
 
 if [ -f "$HOME/.laptop.local" ]; then
   fancy_echo "Running your customizations from ~/.laptop.local ..."


### PR DESCRIPTION
Caught this while running the script on my new M1. The Django repo actually wants Node 16, which is good, because 10 and 12 aren't LTS any more. https://github.com/CoProcure/coprocure.us-django/blob/4788c95cad7b42cce7857905f6d361a5d462cce8/.nvmrc#L1