### PR TITLE
fix(script): install nvm via install script, not brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Optionally, review the log:
 less ~/laptop.log
 ```
 
+The script modifies your terminal configuration (e.g. to add NVM to $PATH). If you want to pick up those changes without opening a new terminal, source your config file like so (substituting .bashrc if you're using bash).
+
+```sh
+source ~/.zshrc
+```
+
 Debugging
 ---------
 

--- a/mac
+++ b/mac
@@ -108,6 +108,13 @@ if brew list | grep -Fq brew-cask; then
   brew uninstall --force brew-cask
 fi
 
+if ! command -v nvm >/dev/null; then
+  fancy_echo "Installing nvm ..."
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+fi
+
 fancy_echo "Please review and customize this script before running so that it meets your needs!"
 fancy_echo "Updating Homebrew formulae ..."
 brew update --force # https://github.com/Homebrew/brew/issues/1151
@@ -126,7 +133,6 @@ brew "zsh"
 brew "libyaml" # should come after openssl
 cask "gpg-suite"
 brew "rbenv"
-brew "nvm"
 brew "pyenv"
 brew "pipenv"
 brew "tfenv"


### PR DESCRIPTION
Per https://github.com/nvm-sh/nvm installing NVM via Homebrew is not supported. Use the recommended install script instead.

I haven't tested this yet and I would guess it likely doesn't work. Putting it up as a draft mostly just to get eyeballs on it in advance of Julie joining. I'll test in a different login.