### PR TITLE
chore(script): don't install git through brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Older versions may work but haven't been tested recently.
 Install
 -------
 
+Make sure you have git installed. On macOS, just typing `git` in the terminal should prompt you to install the Command Line Tools, but if not, `xcode-select --install` should do the trick.
+
 Download the script:
 
 ```sh

--- a/mac
+++ b/mac
@@ -115,7 +115,6 @@ brew bundle --file=- <<EOF
 tap "homebrew/services"
 
 # Unix
-brew "git"
 brew "htop"
 brew "openssl"
 brew "the_silver_searcher"


### PR DESCRIPTION
Installing Git through Apple's own Command Line Tools is preferred to going through Brew.