### PR TITLE
remove homebrew/services from script

### DIFF
--- a/mac
+++ b/mac
@@ -128,7 +128,6 @@ fancy_echo "Please review and customize this script before running so that it me
 fancy_echo "Updating Homebrew formulae ..."
 brew update --force # https://github.com/Homebrew/brew/issues/1151
 brew bundle --file=- <<EOF
-tap "homebrew/services"
 
 # Unix
 brew "htop"


### PR DESCRIPTION
apparently it is deprecated. saw this error while running the script:


```
Tapping homebrew/services has failed!
Error: homebrew/services was deprecated. This tap is now empty and all its contents were either deleted or migrated.
```